### PR TITLE
use default storage class for dynamic provisioning

### DIFF
--- a/deploy/crds/elasticstack.ibm.com_v1alpha1_elasticstack_cr.yaml
+++ b/deploy/crds/elasticstack.ibm.com_v1alpha1_elasticstack_cr.yaml
@@ -62,7 +62,7 @@ spec:
           value: ""
         size: 10Gi
         storageClass: ""
-        useDynamicProvisioning: false
+        useDynamicProvisioning: true
       tolerations: null
     image:
       repository: quay.io/opencloudio/icp-elasticsearch-oss

--- a/deploy/olm-catalog/ibm-elastic-stack-operator/3.0.5/ibm-elastic-stack-operator.v3.0.5.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-elastic-stack-operator/3.0.5/ibm-elastic-stack-operator.v3.0.5.clusterserviceversion.yaml
@@ -41,7 +41,8 @@ metadata:
               "data": {
                 "replicas": 1,
                 "storage": {
-                  "persistent": true
+                  "persistent": true,
+                  "useDynamicProvisioning": true
                 },
                 "tolerations": [
                   {

--- a/helm-charts/ibm-icplogging/templates/es-data-statefulset.yaml
+++ b/helm-charts/ibm-icplogging/templates/es-data-statefulset.yaml
@@ -95,7 +95,7 @@ spec:
     {{- end }}
     {{- if eq (.Values.general.environment | lower) "openshift" }}
       securityContext:
-        #fsGroup: 1001
+        fsGroup: 1001
     {{- else }}
       securityContext:
         fsGroup: 1000


### PR DESCRIPTION
- tests on fyre showed if storage class left to default, not able to bind ppc. @horis233 indicated this is due to fyre clusters didn't have a default provisioning
- fixed fs permission issue on aws
- tested on aws for default provisioning and fs permission