### PR TITLE
Add namespace selector of netowrkpolicy to support VA case

### DIFF
--- a/helm-charts/ibm-icplogging/templates/es-data-netpol.yaml
+++ b/helm-charts/ibm-icplogging/templates/es-data-netpol.yaml
@@ -33,6 +33,13 @@ spec:
           heritage: "{{ .Release.Service }}"
   - ports:
     - port: 8443
+    from:
+    - podSelector:
+        matchLabels:
+    - namespaceSelector:
+        matchLabels:
+          app: vulnerability-advisor
+  - ports:
     - port: 9200
     from:
     - namespaceSelector:

--- a/helm-charts/ibm-icplogging/templates/es-data-netpol.yaml
+++ b/helm-charts/ibm-icplogging/templates/es-data-netpol.yaml
@@ -33,6 +33,8 @@ spec:
           heritage: "{{ .Release.Service }}"
   - ports:
     - port: 8443
+    - port: 9200
     from:
-    - podSelector:
+    - namespaceSelector:
         matchLabels:
+          app: vulnerability-advisor

--- a/helm-charts/ibm-icplogging/templates/es-data-netpol.yaml
+++ b/helm-charts/ibm-icplogging/templates/es-data-netpol.yaml
@@ -39,9 +39,3 @@ spec:
     - namespaceSelector:
         matchLabels:
           app: vulnerability-advisor
-  - ports:
-    - port: 9200
-    from:
-    - namespaceSelector:
-        matchLabels:
-          app: vulnerability-advisor


### PR DESCRIPTION
Add namespace selector of netowrkpolicy, VA pods in namespace with label `app: vulnerability-advisor` can accesss logging elasticsearch