### PR TITLE
enable force upgrade 37108

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM quay.io/operator-framework/helm-operator:v0.17.0
+FROM quay.io/operator-framework/helm-operator:v0.17.1
 
 LABEL org.label-schema.vendor="IBM" \
     org.label-schema.name="ibm-elastic-stack-operator" \

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM quay.io/operator-framework/helm-operator-ppc64le:v0.17.0
+FROM quay.io/operator-framework/helm-operator-ppc64le:v0.17.1
 
 LABEL org.label-schema.vendor="IBM" \
     org.label-schema.name="ibm-elastic-stack-operator" \

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM quay.io/operator-framework/helm-operator-s390x:v0.17.0
+FROM quay.io/operator-framework/helm-operator-s390x:v0.17.1
 
 LABEL org.label-schema.vendor="IBM" \
     org.label-schema.name="ibm-elastic-stack-operator" \

--- a/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.2/ibm-elastic-stack-operator.v3.1.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.2/ibm-elastic-stack-operator.v3.1.2.clusterserviceversion.yaml
@@ -11,7 +11,10 @@ metadata:
           "apiVersion": "elasticstack.ibm.com/v1alpha1",
           "kind": "ElasticStack",
           "metadata": {
-            "name": "logging"
+            "name": "logging",
+            "annotations": {
+              "helm.operator-sdk/upgrade-force": "True"
+            }
           },
           "spec": {
             "image": {


### PR DESCRIPTION
- switched to 0.17.1 base
- added force option

tests show the base image is still having issues parsing the parameter. commented in the public git ticket (do not have permission to reopen): 
https://github.com/operator-framework/operator-sdk/issues/2884#issuecomment-634900405