### PR TITLE
Fix license documentation in deploy & helm-charts dir

### DIFF
--- a/deploy/crds/elasticstack.ibm.com_elasticstacks_crd.yaml
+++ b/deploy/crds/elasticstack.ibm.com_elasticstacks_crd.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/crds/elasticstack.ibm.com_v1alpha1_elasticstack_cr.yaml
+++ b/deploy/crds/elasticstack.ibm.com_v1alpha1_elasticstack_cr.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: elasticstack.ibm.com/v1alpha1
 kind: ElasticStack
 metadata:

--- a/deploy/olm-catalog/ibm-elastic-stack-operator/3.0.5/elasticstack.ibm.com_elasticstacks_crd.yaml
+++ b/deploy/olm-catalog/ibm-elastic-stack-operator/3.0.5/elasticstack.ibm.com_elasticstacks_crd.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/ibm-elastic-stack-operator/3.0.5/ibm-elastic-stack-operator.v3.0.5.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-elastic-stack-operator/3.0.5/ibm-elastic-stack-operator.v3.0.5.clusterserviceversion.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:

--- a/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.1/elasticstack.ibm.com_elasticstacks_crd.yaml
+++ b/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.1/elasticstack.ibm.com_elasticstacks_crd.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.1/ibm-elastic-stack-operator.v3.1.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.1/ibm-elastic-stack-operator.v3.1.1.clusterserviceversion.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:

--- a/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.2/elasticstack.ibm.com_elasticstacks_crd.yaml
+++ b/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.2/elasticstack.ibm.com_elasticstacks_crd.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.2/ibm-elastic-stack-operator.v3.1.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.2/ibm-elastic-stack-operator.v3.1.2.clusterserviceversion.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:

--- a/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.3/elasticstack.ibm.com_elasticstacks_crd.yaml
+++ b/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.3/elasticstack.ibm.com_elasticstacks_crd.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.3/ibm-elastic-stack-operator.v3.1.3.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.3/ibm-elastic-stack-operator.v3.1.3.clusterserviceversion.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:

--- a/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.4/elasticstack.ibm.com_elasticstacks_crd.yaml
+++ b/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.4/elasticstack.ibm.com_elasticstacks_crd.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.4/ibm-elastic-stack-operator.v3.1.4.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-elastic-stack-operator/3.1.4/ibm-elastic-stack-operator.v3.1.4.clusterserviceversion.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:

--- a/deploy/olm-catalog/ibm-elastic-stack-operator/ibm-elastic-stack-operator.package.yaml
+++ b/deploy/olm-catalog/ibm-elastic-stack-operator/ibm-elastic-stack-operator.package.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 channels:
 - currentCSV: ibm-elastic-stack-operator.v3.1.4
   name: dev

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/deploy/sample-crs/managed-stack.scc.yaml
+++ b/deploy/sample-crs/managed-stack.scc.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
 metadata:

--- a/deploy/sample-crs/managed-stack.yaml
+++ b/deploy/sample-crs/managed-stack.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {
   "apiVersion": "elasticstack.ibm.com/v1alpha1",
   "kind": "ElasticStack",

--- a/deploy/sample-crs/minimal-stack.yaml
+++ b/deploy/sample-crs/minimal-stack.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: elasticstack.ibm.com/v1alpha1
 kind: ElasticStack
 metadata:

--- a/deploy/sample-crs/tenant-a.sample.yaml
+++ b/deploy/sample-crs/tenant-a.sample.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: elasticstack.ibm.com/v1alpha1
 kind: ElasticStack
 metadata:

--- a/deploy/sample-crs/tenant-a.scc.yaml
+++ b/deploy/sample-crs/tenant-a.scc.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 kind: SecurityContextConstraints
 apiVersion: v1
 metadata:

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm-charts/ibm-icplogging/elasticsearch/general.config
+++ b/helm-charts/ibm-icplogging/elasticsearch/general.config
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cluster.name: "{{ .Values.elasticsearch.name }}"
 node.name: ${HOSTNAME}
 

--- a/helm-charts/ibm-icplogging/es-client-router/nginx.conf
+++ b/helm-charts/ibm-icplogging/es-client-router/nginx.conf
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 daemon off;
 error_log stderr info;
 

--- a/helm-charts/ibm-icplogging/es-client-router/qparser.lua
+++ b/helm-charts/ibm-icplogging/es-client-router/qparser.lua
@@ -1,7 +1,17 @@
--- Licensed Materials - Property of IBM
--- 5737-E67
--- @ Copyright IBM Corporation 2016, 2019. All Rights Reserved.
--- US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+-- 
+-- Copyright 2020 IBM Corporation
+
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+
+-- http:#www.apache.org/licenses/LICENSE-2.0
+
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
 --
 -- this query-parser parses the  request body of elastic "search" queries
 -- note: search calls coming in from kibana are multisearch  (_msearch) queries,

--- a/helm-charts/ibm-icplogging/es-client-router/rbac.lua
+++ b/helm-charts/ibm-icplogging/es-client-router/rbac.lua
@@ -1,7 +1,17 @@
--- Licensed Materials - Property of IBM
--- 5737-E67
--- @ Copyright IBM Corporation 2016, 2019. All Rights Reserved.
--- US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+-- 
+-- Copyright 2020 IBM Corporation
+
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+
+-- http:#www.apache.org/licenses/LICENSE-2.0
+
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
 
 local cjson = require "cjson"
 local cookiejar = require "resty.cookie"

--- a/helm-charts/ibm-icplogging/es-migration/migrate-elk551-data.sh
+++ b/helm-charts/ibm-icplogging/es-migration/migrate-elk551-data.sh
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http:#www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #!/bin/bash
 ESROOT=/usr/share/elasticsearch/data
 ES66=6.x

--- a/helm-charts/ibm-icplogging/filebeat/filebeat.yml
+++ b/helm-charts/ibm-icplogging/filebeat/filebeat.yml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http:#www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 filebeat.config:
   inputs:
     # Mounted `filebeat-inputs` configmap:

--- a/helm-charts/ibm-icplogging/filebeat/k8s.yml
+++ b/helm-charts/ibm-icplogging/filebeat/k8s.yml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http:#www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 - type: log
   paths:
   {{- if .Values.filebeat.scope.namespaces }}

--- a/helm-charts/ibm-icplogging/ibm_cloud_pak/manifest.yaml
+++ b/helm-charts/ibm-icplogging/ibm_cloud_pak/manifest.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http:#www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 images:
 - image: ibm-elastic-stack-operator:3.1.4
   references:

--- a/helm-charts/ibm-icplogging/kibana-init/entrypoint.sh
+++ b/helm-charts/ibm-icplogging/kibana-init/entrypoint.sh
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http:#www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{ template "elk.settings.all.prepare" . -}}
 
 #!/bin/sh

--- a/helm-charts/ibm-icplogging/kibana-migration-check/check-migration.sh
+++ b/helm-charts/ibm-icplogging/kibana-migration-check/check-migration.sh
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http:#www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{ template "elk.settings.all.prepare" . -}}
 
 #!/bin/sh

--- a/helm-charts/ibm-icplogging/kibana-migration/migrate.sh
+++ b/helm-charts/ibm-icplogging/kibana-migration/migrate.sh
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http:#www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{ template "elk.settings.all.prepare" . -}}
 
 #!/bin/sh

--- a/helm-charts/ibm-icplogging/kibana-router/nginx.conf
+++ b/helm-charts/ibm-icplogging/kibana-router/nginx.conf
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http:#www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{ template "elk.settings.all.prepare" . -}}
 daemon off;
 error_log stderr debug;

--- a/helm-charts/ibm-icplogging/kibana/kibana.yml
+++ b/helm-charts/ibm-icplogging/kibana/kibana.yml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http:#www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{ template "elk.settings.all.prepare" . -}}
 
 # 1. kibana general settings

--- a/helm-charts/ibm-icplogging/templates/_helpers.tpl
+++ b/helm-charts/ibm-icplogging/templates/_helpers.tpl
@@ -1,8 +1,17 @@
 {{/*
-  Licensed Materials - Property of IBM
-  5737-E67
-  @ Copyright IBM Corporation 2016, 2019. All Rights Reserved.
-  US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+  Copyright 2020 IBM Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http:#www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 */}}
 
 {{/* vim: set filetype=mustache: */}}

--- a/helm-charts/ibm-icplogging/templates/_version.tpl
+++ b/helm-charts/ibm-icplogging/templates/_version.tpl
@@ -1,3 +1,19 @@
+{{/*
+  Copyright 2020 IBM Corporation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http:#www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
 {{- /*
 "sch.version" contains the version information and tillerVersion constraint
 for this version of the Shared Configurable Helpers.

--- a/helm-charts/ibm-icplogging/templates/es-data-netpol.yaml
+++ b/helm-charts/ibm-icplogging/templates/es-data-netpol.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:

--- a/helm-charts/ibm-icplogging/templates/es-sa.yaml
+++ b/helm-charts/ibm-icplogging/templates/es-sa.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm-charts/ibm-icplogging/templates/fb-input-config.yaml
+++ b/helm-charts/ibm-icplogging/templates/fb-input-config.yaml
@@ -1,7 +1,17 @@
-# Licensed Materials - Property of IBM
-# 5737-E67
-# @ Copyright IBM Corporation 2016, 2018. All Rights Reserved.
-# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 apiVersion: v1
 kind: ConfigMap

--- a/helm-charts/ibm-icplogging/templates/fb-sa.yaml
+++ b/helm-charts/ibm-icplogging/templates/fb-sa.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm-charts/ibm-icplogging/templates/job-sa.yaml
+++ b/helm-charts/ibm-icplogging/templates/job-sa.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm-charts/ibm-icplogging/templates/kibana-migration-check-config.yaml
+++ b/helm-charts/ibm-icplogging/templates/kibana-migration-check-config.yaml
@@ -1,9 +1,19 @@
 {{- if .Values.kibana.install -}}
 
-# Licensed Materials - Property of IBM
-# 5737-E67
-# @ Copyright IBM Corporation 2016, 2018. All Rights Reserved.
-# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 apiVersion: v1
 kind: ConfigMap

--- a/helm-charts/ibm-icplogging/templates/kibana-sa.yaml
+++ b/helm-charts/ibm-icplogging/templates/kibana-sa.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm-charts/ibm-icplogging/templates/ls-sa.yaml
+++ b/helm-charts/ibm-icplogging/templates/ls-sa.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
Added appropriate licensing headers to most of the files within these directories.